### PR TITLE
Remove unused help text for shortened URL link in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -338,9 +338,6 @@
                 <input type="text" id="shortUrlOutput" readonly>
                 <button class="copy-btn" onclick="copyToClipboard()">Copy</button>
             </div>
-            <div class="help-text" id="shortUrlLinkWrapper" style="margin-top: 10px; display: none;">
-                <a id="shortUrlLink" href="#" target="_blank" rel="noopener noreferrer"></a>
-            </div>
         </div>
     </div>
 


### PR DESCRIPTION
This pull request makes a minor change to the `docs/index.html` file by removing the section that displayed the shortened URL as a clickable link below the output field.