### PR TITLE
Refactor Worker Into Shared lib and Add Observability

### DIFF
--- a/.github/workflows/bump-patch-version.yml
+++ b/.github/workflows/bump-patch-version.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Bump patch version
         id: bump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           # Check that required files exist
           test -f package.json || (echo "package.json missing" && exit 1)
           test -f src/worker.example.js || (echo "src/worker.example.js missing" && exit 1)
+          test -d src/lib || (echo "src/lib missing" && exit 1)
           test -f README.md || (echo "README.md missing" && exit 1)
           echo "Package structure verified ✓"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        node-version: ["18", "20"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "24"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Enable Corepack
         run: corepack enable

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "logs": "wrangler tail",
     "preview": "wrangler dev",
     "publish:npmjs": "pnpm publish --registry https://registry.npmjs.org",
     "publish:github": "pnpm publish --registry https://npm.pkg.github.com",
@@ -45,6 +46,7 @@
   "files": [
     "src/worker.js",
     "src/worker.example.js",
+    "src/lib/",
     "config/",
     "docs/",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/dytsou/shorten-url#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=24.0.0"
   },
   "devDependencies": {
     "prettier": "^3.7.4",

--- a/src/lib/access.js
+++ b/src/lib/access.js
@@ -1,0 +1,5 @@
+export function hasPassedAccess(request) {
+  const jwt = request.headers.get("Cf-Access-Jwt-Assertion");
+  const email = request.headers.get("Cf-Access-Authenticated-User-Email");
+  return Boolean(jwt && email);
+}

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,0 +1,2 @@
+export const SLUG_PATTERN = /^[a-zA-Z0-9\-_]+$/;
+export const URL_PATTERN = /http(s)?:\/\/([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?/;

--- a/src/lib/crypto.js
+++ b/src/lib/crypto.js
@@ -1,0 +1,18 @@
+export function randomString(worker, len = worker.min_random_key_length) {
+  const chars = worker.random_chars;
+  const bytes = new Uint8Array(len);
+  crypto.getRandomValues(bytes);
+  let result = "";
+  for (let i = 0; i < len; i++) {
+    result += chars.charAt(bytes[i] % chars.length);
+  }
+  return result;
+}
+
+export async function sha512(text) {
+  const data = new TextEncoder().encode(text);
+  const digest = await crypto.subtle.digest("SHA-512", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/lib/endpoints.js
+++ b/src/lib/endpoints.js
@@ -1,0 +1,12 @@
+/** Build hosted page URLs from a frontend config object. */
+export function endpointsFromFrontend(frontend) {
+  const pagesBase = frontend.pagesBase || frontend.url;
+  return {
+    shortenPage: frontend.url,
+    notFoundPage: new URL("404.html", pagesBase).href,
+    errorPage: new URL("error.html", pagesBase).href,
+    safeBrowsingWarning: new URL("safe-browsing-warning.html", pagesBase).href,
+    noRefPage: new URL("no-ref-page.html", pagesBase).href,
+    safeBrowsing: "https://safebrowsing.googleapis.com/v4/threatMatches:find",
+  };
+}

--- a/src/lib/kv.js
+++ b/src/lib/kv.js
@@ -1,5 +1,4 @@
-import { randomString } from "./crypto.js";
-import { sha512 } from "./crypto.js";
+import { randomString, sha512 } from "./crypto.js";
 import { logError, traceSpan } from "./observability.js";
 
 export function createKvStore({ worker, kv }) {

--- a/src/lib/kv.js
+++ b/src/lib/kv.js
@@ -1,0 +1,50 @@
+import { randomString } from "./crypto.js";
+import { sha512 } from "./crypto.js";
+import { logError, traceSpan } from "./observability.js";
+
+export function createKvStore({ worker, kv }) {
+  async function saveUrl(url, customSlug = null) {
+    return traceSpan("kv.save", async (span) => {
+      if (span.isTraced) span.setAttribute("kv.custom_slug", Boolean(customSlug));
+      try {
+        const key = customSlug || randomString(worker);
+        const existing = await kv.get(key);
+
+        if (existing === null) {
+          await kv.put(key, url);
+          return [undefined, key];
+        }
+        if (customSlug) {
+          return ["CUSTOM_SLUG_EXISTS", null];
+        }
+        return saveUrl(url);
+      } catch (error) {
+        logError("kv.save_failed", error);
+        return ["KV_ERROR", null];
+      }
+    });
+  }
+
+  async function findUrlKeyByHash(urlHash) {
+    return (await kv.get(urlHash)) || null;
+  }
+
+  async function resolveShortKey(longUrl, customSlug) {
+    return traceSpan("kv.resolve", async (span) => {
+      if (span.isTraced) span.setAttribute("kv.unique_link", worker.unique_link);
+      if (worker.unique_link && !customSlug) {
+        const urlHash = await sha512(longUrl);
+        const existingKey = await findUrlKeyByHash(urlHash);
+        if (existingKey) {
+          return [undefined, existingKey];
+        }
+        const [errorCode, key] = await saveUrl(longUrl);
+        if (errorCode === undefined) await kv.put(urlHash, key);
+        return [errorCode, key];
+      }
+      return saveUrl(longUrl, customSlug);
+    });
+  }
+
+  return { saveUrl, findUrlKeyByHash, resolveShortKey };
+}

--- a/src/lib/observability.js
+++ b/src/lib/observability.js
@@ -48,29 +48,29 @@ function setRequestSpanAttributes(span, request) {
 
 /** Wrap a Worker fetch handler with request-level spans and structured logs. */
 export function withFetchObservability(handler) {
-  return {
-    async fetch(request, env, ctx) {
-      return tracing.enterSpan("fetch", async (span) => {
-        const fields = requestFields(request);
-        setRequestSpanAttributes(span, request);
-        log("info", "request.start", fields);
+  async function observedFetch(request, env, ctx) {
+    return tracing.enterSpan("fetch", async (span) => {
+      const fields = requestFields(request);
+      setRequestSpanAttributes(span, request);
+      log("info", "request.start", fields);
 
-        try {
-          const response = await handler(request, env, ctx);
-          const status = response.status;
-          if (span.isTraced) span.setAttribute("http.response.status_code", status);
-          log("info", "request.complete", {
-            ...fields,
-            http: { ...fields.http, status },
-          });
-          return response;
-        } catch (error) {
-          logError("request.error", error, fields);
-          throw error;
-        }
-      });
-    },
-  };
+      try {
+        const response = await handler(request, env, ctx);
+        const status = response.status;
+        if (span.isTraced) span.setAttribute("http.response.status_code", status);
+        log("info", "request.complete", {
+          ...fields,
+          http: { ...fields.http, status },
+        });
+        return response;
+      } catch (error) {
+        logError("request.error", error, fields);
+        throw error;
+      }
+    });
+  }
+
+  return { fetch: observedFetch };
 }
 
 /** Run async work inside a named custom span. */

--- a/src/lib/observability.js
+++ b/src/lib/observability.js
@@ -1,0 +1,86 @@
+import { tracing } from "cloudflare:workers";
+
+/** Structured JSON log for Workers Logs indexing. */
+export function log(level, event, fields = {}) {
+  console.log({ level, event, ts: new Date().toISOString(), ...fields });
+}
+
+export function logError(event, error, fields = {}) {
+  console.error({
+    level: "error",
+    event,
+    ts: new Date().toISOString(),
+    error:
+      error instanceof Error
+        ? { message: error.message, name: error.name }
+        : { message: String(error) },
+    ...fields,
+  });
+}
+
+export function requestFields(request) {
+  const url = new URL(request.url);
+  return {
+    http: {
+      method: request.method,
+      path: url.pathname,
+      ...(url.search ? { query: url.search } : {}),
+    },
+    ...(request.cf?.colo || request.cf?.country
+      ? {
+          client: {
+            ...(request.cf.colo ? { colo: request.cf.colo } : {}),
+            ...(request.cf.country ? { country: request.cf.country } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function setRequestSpanAttributes(span, request) {
+  if (!span.isTraced) return;
+  const url = new URL(request.url);
+  span.setAttribute("http.request.method", request.method);
+  span.setAttribute("url.path", url.pathname);
+  if (request.cf?.colo) span.setAttribute("cf.colo", request.cf.colo);
+  if (request.cf?.country) span.setAttribute("cf.country", request.cf.country);
+}
+
+/** Wrap a Worker fetch handler with request-level spans and structured logs. */
+export function withFetchObservability(handler) {
+  return {
+    async fetch(request, env, ctx) {
+      return tracing.enterSpan("fetch", async (span) => {
+        const fields = requestFields(request);
+        setRequestSpanAttributes(span, request);
+        log("info", "request.start", fields);
+
+        try {
+          const response = await handler(request, env, ctx);
+          const status = response.status;
+          if (span.isTraced) span.setAttribute("http.response.status_code", status);
+          log("info", "request.complete", {
+            ...fields,
+            http: { ...fields.http, status },
+          });
+          return response;
+        } catch (error) {
+          logError("request.error", error, fields);
+          throw error;
+        }
+      });
+    },
+  };
+}
+
+/** Run async work inside a named custom span. */
+export function traceSpan(name, fn, attributes = {}) {
+  return tracing.enterSpan(name, async (span) => {
+    if (span.isTraced) {
+      for (const [key, value] of Object.entries(attributes)) {
+        if (value !== undefined) span.setAttribute(key, value);
+      }
+    }
+    return fn(span);
+  });
+}

--- a/src/lib/responses.js
+++ b/src/lib/responses.js
@@ -1,5 +1,19 @@
 import { wantsJson } from "./validate.js";
 
+async function fetchHostedPage(url, status = 200) {
+  const upstream = await fetch(url, { redirect: "follow" });
+  return new Response(await upstream.text(), {
+    status,
+    headers: { "content-type": "text/html;charset=UTF-8" },
+  });
+}
+
+async function fetchInterstitial(url, destination) {
+  const upstream = await fetch(url);
+  const html = (await upstream.text()).replace(/{Replace}/gm, destination);
+  return new Response(html, { headers: { "content-type": "text/html;charset=UTF-8" } });
+}
+
 export function createResponses({ worker, endpoints }) {
   function corsHeaders() {
     if (worker.cors !== "on") return {};
@@ -19,20 +33,6 @@ export function createResponses({ worker, endpoints }) {
 
   function jsonResponse(payload, status) {
     return new Response(JSON.stringify(payload), { status, headers: jsonHeaders() });
-  }
-
-  async function fetchHostedPage(url, status = 200) {
-    const upstream = await fetch(url, { redirect: "follow" });
-    return new Response(await upstream.text(), {
-      status,
-      headers: { "content-type": "text/html;charset=UTF-8" },
-    });
-  }
-
-  async function fetchInterstitial(url, destination) {
-    const upstream = await fetch(url);
-    const html = (await upstream.text()).replace(/{Replace}/gm, destination);
-    return new Response(html, { headers: { "content-type": "text/html;charset=UTF-8" } });
   }
 
   async function errorResponse(message, code, request) {

--- a/src/lib/responses.js
+++ b/src/lib/responses.js
@@ -1,0 +1,63 @@
+import { wantsJson } from "./validate.js";
+
+export function createResponses({ worker, endpoints }) {
+  function corsHeaders() {
+    if (worker.cors !== "on") return {};
+    return {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+    };
+  }
+
+  function htmlHeaders() {
+    return { "content-type": "text/html;charset=UTF-8", ...corsHeaders() };
+  }
+
+  function jsonHeaders() {
+    return { "content-type": "application/json;charset=UTF-8", ...corsHeaders() };
+  }
+
+  function jsonResponse(payload, status) {
+    return new Response(JSON.stringify(payload), { status, headers: jsonHeaders() });
+  }
+
+  async function fetchHostedPage(url, status = 200) {
+    const upstream = await fetch(url, { redirect: "follow" });
+    return new Response(await upstream.text(), {
+      status,
+      headers: { "content-type": "text/html;charset=UTF-8" },
+    });
+  }
+
+  async function fetchInterstitial(url, destination) {
+    const upstream = await fetch(url);
+    const html = (await upstream.text()).replace(/{Replace}/gm, destination);
+    return new Response(html, { headers: { "content-type": "text/html;charset=UTF-8" } });
+  }
+
+  async function errorResponse(message, code, request) {
+    if (wantsJson(request) || !endpoints.errorPage) {
+      return jsonResponse({ status: code, message }, code);
+    }
+    const url = `${endpoints.errorPage}?message=${encodeURIComponent(message)}&code=${encodeURIComponent(code)}`;
+    return fetchHostedPage(url, code);
+  }
+
+  function notFound() {
+    if (!endpoints.notFoundPage) {
+      return jsonResponse({ status: 404, message: "URL not found" }, 404);
+    }
+    return fetchHostedPage(endpoints.notFoundPage, 404);
+  }
+
+  return {
+    corsHeaders,
+    htmlHeaders,
+    jsonHeaders,
+    jsonResponse,
+    fetchHostedPage,
+    fetchInterstitial,
+    errorResponse,
+    notFound,
+  };
+}

--- a/src/lib/safety.js
+++ b/src/lib/safety.js
@@ -1,0 +1,28 @@
+import { traceSpan } from "./observability.js";
+
+export async function isUrlSafe(url, worker, endpoints) {
+  return traceSpan("safe_browsing.check", async () => {
+    const body = JSON.stringify({
+      client: { clientId: "Url-Shorten-Worker", clientVersion: "1.0.7" },
+      threatInfo: {
+        threatTypes: [
+          "MALWARE",
+          "SOCIAL_ENGINEERING",
+          "POTENTIALLY_HARMFUL_APPLICATION",
+          "UNWANTED_SOFTWARE",
+        ],
+        platformTypes: ["ANY_PLATFORM"],
+        threatEntryTypes: ["URL"],
+        threatEntries: [{ url }],
+      },
+    });
+
+    const response = await fetch(`${endpoints.safeBrowsing}?key=${worker.safe_browsing_api_key}`, {
+      method: "POST",
+      body,
+      redirect: "follow",
+    });
+    const result = await response.json();
+    return Object.keys(result).length === 0;
+  });
+}

--- a/src/lib/shortener.js
+++ b/src/lib/shortener.js
@@ -8,6 +8,7 @@ import { isValidCustomSlug, isValidUrl } from "./validate.js";
 export function createShortener({ worker, endpoints, kv }) {
   const responses = createResponses({ worker, endpoints });
   const kvStore = createKvStore({ worker, kv });
+  const reservedSlugSet = new Set(worker.reserved_slugs.map((s) => s.toLowerCase()));
   const { jsonResponse, fetchInterstitial, errorResponse, notFound } = responses;
   const { resolveShortKey } = kvStore;
 
@@ -34,7 +35,7 @@ export function createShortener({ worker, endpoints, kv }) {
     if (!worker.custom_link) {
       return { error: await errorResponse("Custom URLs are disabled", 400, request) };
     }
-    if (!isValidCustomSlug(customSlug, worker)) {
+    if (!isValidCustomSlug(customSlug, worker, reservedSlugSet)) {
       return { error: await errorResponse("Invalid custom slug format", 400, request) };
     }
     return { longUrl, customSlug };
@@ -48,7 +49,9 @@ export function createShortener({ worker, endpoints, kv }) {
     return traceSpan("shorten", async (span) => {
       if (span.isTraced) span.setAttribute("api.path", apiPath);
 
-      if (!allowedApiPaths.includes(apiPath)) {
+      const allowedPaths =
+        allowedApiPaths instanceof Set ? allowedApiPaths : new Set(allowedApiPaths);
+      if (!allowedPaths.has(apiPath)) {
         return jsonResponse({ status: 404, message: "Invalid API path" }, 404);
       }
 

--- a/src/lib/shortener.js
+++ b/src/lib/shortener.js
@@ -1,0 +1,116 @@
+import { hasPassedAccess } from "./access.js";
+import { createKvStore } from "./kv.js";
+import { log, logError, traceSpan } from "./observability.js";
+import { createResponses } from "./responses.js";
+import { isUrlSafe } from "./safety.js";
+import { isValidCustomSlug, isValidUrl } from "./validate.js";
+
+export function createShortener({ worker, endpoints, kv }) {
+  const responses = createResponses({ worker, endpoints });
+  const kvStore = createKvStore({ worker, kv });
+  const { jsonResponse, fetchInterstitial, errorResponse, notFound } = responses;
+  const { resolveShortKey } = kvStore;
+
+  function respondToSaveError(errorCode, request) {
+    if (errorCode === "CUSTOM_SLUG_EXISTS") {
+      return errorResponse("Custom slug already exists", 400, request);
+    }
+    if (errorCode === "KV_ERROR") {
+      return errorResponse("Database error occurred", 500, request);
+    }
+    return errorResponse("Error: Reach the KV write limitation", 500, request);
+  }
+
+  async function validateShortenPayload(body, request) {
+    const longUrl = body.url;
+    if (!longUrl) return { error: await errorResponse("URL is required", 400, request) };
+    if (!isValidUrl(longUrl)) {
+      return { error: await errorResponse("Invalid URL format", 400, request) };
+    }
+
+    const customSlug = body.custom_slug || null;
+    if (!customSlug) return { longUrl, customSlug: null };
+
+    if (!worker.custom_link) {
+      return { error: await errorResponse("Custom URLs are disabled", 400, request) };
+    }
+    if (!isValidCustomSlug(customSlug, worker)) {
+      return { error: await errorResponse("Invalid custom slug format", 400, request) };
+    }
+    return { longUrl, customSlug };
+  }
+
+  async function handleShorten(
+    request,
+    requestURL,
+    { apiPath = "/", allowedApiPaths = ["/"], requireAccess = true } = {}
+  ) {
+    return traceSpan("shorten", async (span) => {
+      if (span.isTraced) span.setAttribute("api.path", apiPath);
+
+      if (!allowedApiPaths.includes(apiPath)) {
+        return jsonResponse({ status: 404, message: "Invalid API path" }, 404);
+      }
+
+      if (requireAccess && !hasPassedAccess(request)) {
+        log("warn", "shorten.access_denied", { api: { path: apiPath } });
+        return errorResponse("You must use WARP to shorten the URL", 403, request);
+      }
+
+      let body;
+      try {
+        body = await request.json();
+      } catch (error) {
+        logError("shorten.invalid_json", error, { api: { path: apiPath } });
+        return errorResponse("Invalid JSON format", 400, request);
+      }
+
+      const validated = await validateShortenPayload(body, request);
+      if (validated.error) return validated.error;
+
+      const [errorCode, key] = await resolveShortKey(validated.longUrl, validated.customSlug);
+      if (errorCode === undefined) {
+        log("info", "shorten.created", {
+          key,
+          custom_slug: Boolean(validated.customSlug),
+        });
+        return jsonResponse({ short_url: `${requestURL.origin}/${key}` }, 201);
+      }
+      log("warn", "shorten.save_failed", { error_code: errorCode });
+      return respondToSaveError(errorCode, request);
+    });
+  }
+
+  async function handleShortUrlRedirect(path, params, suffix = null) {
+    return traceSpan("redirect", async (span) => {
+      const key = suffix ? `${path}/${suffix}` : path;
+      if (span.isTraced) span.setAttribute("shortlink.key", key || "");
+
+      if (!key) return notFound();
+
+      const value = await kv.get(key);
+      if (!value) {
+        log("info", "redirect.not_found", { key });
+        return notFound();
+      }
+
+      const destination = params ? value + params : value;
+
+      if (worker.safe_browsing_api_key && !(await isUrlSafe(destination, worker, endpoints))) {
+        log("warn", "redirect.unsafe_url", { key });
+        return fetchInterstitial(endpoints.safeBrowsingWarning, destination);
+      }
+      if (worker.no_ref === "on") {
+        return fetchInterstitial(endpoints.noRefPage, destination);
+      }
+      log("info", "redirect.success", { key });
+      return Response.redirect(destination, 302);
+    });
+  }
+
+  return {
+    ...responses,
+    handleShorten,
+    handleShortUrlRedirect,
+  };
+}

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -4,12 +4,16 @@ export function isValidUrl(url) {
   return typeof url === "string" && url.startsWith("h") && URL_PATTERN.test(url);
 }
 
-export function isValidCustomSlug(slug, worker) {
+export function isValidCustomSlug(slug, worker, reservedSlugs = worker.reserved_slugs) {
+  const reserved =
+    reservedSlugs instanceof Set
+      ? reservedSlugs
+      : new Set(reservedSlugs.map((s) => s.toLowerCase()));
   return (
     SLUG_PATTERN.test(slug) &&
     slug.length >= 1 &&
     slug.length <= worker.max_custom_slug_length &&
-    !worker.reserved_slugs.includes(slug.toLowerCase())
+    !reserved.has(slug.toLowerCase())
   );
 }
 

--- a/src/lib/validate.js
+++ b/src/lib/validate.js
@@ -1,0 +1,20 @@
+import { SLUG_PATTERN, URL_PATTERN } from "./constants.js";
+
+export function isValidUrl(url) {
+  return typeof url === "string" && url.startsWith("h") && URL_PATTERN.test(url);
+}
+
+export function isValidCustomSlug(slug, worker) {
+  return (
+    SLUG_PATTERN.test(slug) &&
+    slug.length >= 1 &&
+    slug.length <= worker.max_custom_slug_length &&
+    !worker.reserved_slugs.includes(slug.toLowerCase())
+  );
+}
+
+export function wantsJson(request) {
+  const accept = request.headers.get("accept") || "";
+  const contentType = request.headers.get("content-type") || "";
+  return accept.includes("application/json") || contentType.includes("application/json");
+}

--- a/src/worker.example.js
+++ b/src/worker.example.js
@@ -38,7 +38,7 @@ function getEndpoints() {
   return endpointsFromFrontend(config.frontend);
 }
 
-export default withFetchObservability(async (request, env) => {
+async function exampleFetchHandler(request, env) {
   const shortener = createShortener({
     worker: config.worker,
     endpoints: getEndpoints(),
@@ -60,4 +60,6 @@ export default withFetchObservability(async (request, env) => {
   }
   if (!path) return shortener.fetchHostedPage(getEndpoints().shortenPage);
   return shortener.handleShortUrlRedirect(path, params);
-});
+}
+
+export default withFetchObservability(exampleFetchHandler);

--- a/src/worker.example.js
+++ b/src/worker.example.js
@@ -2,7 +2,7 @@
  * URL Shortener — Cloudflare Worker (template)
  *
  * Copy this file to `src/worker.js` and wire in your config (see README).
- * Service-worker syntax. Requires a KV namespace bound as `LINKS`.
+ * Requires a KV namespace bound as `LINKS`.
  *
  * Routes:
  *   OPTIONS *                -> CORS preflight
@@ -10,6 +10,10 @@
  *   GET     /                -> serve the shortener frontend
  *   GET     /<key>           -> redirect a stored short link
  */
+
+import { createShortener } from "./lib/shortener.js";
+import { endpointsFromFrontend } from "./lib/endpoints.js";
+import { withFetchObservability } from "./lib/observability.js";
 
 // ============================================================================
 // Configuration
@@ -30,310 +34,30 @@ try {
   throw error;
 }
 
-const SLUG_PATTERN = /^[a-zA-Z0-9\-_]+$/;
-const URL_PATTERN = /http(s)?:\/\/([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?/;
-
-/** Resolve hosted page URLs from `config.frontend`. */
 function getEndpoints() {
-  // Error/interstitial HTML files may live at the frontend root or a separate Pages path.
-  const pagesBase = config.frontend.pagesBase || config.frontend.url;
-
-  return {
-    shortenPage: config.frontend.url,
-    notFoundPage: new URL("404.html", pagesBase).href,
-    errorPage: new URL("error.html", pagesBase).href,
-    safeBrowsingWarning: new URL("safe-browsing-warning.html", pagesBase).href,
-    noRefPage: new URL("no-ref-page.html", pagesBase).href,
-    safeBrowsing: "https://safebrowsing.googleapis.com/v4/threatMatches:find",
-  };
+  return endpointsFromFrontend(config.frontend);
 }
 
-// ============================================================================
-// Response header helpers
-// ============================================================================
-
-function corsHeaders() {
-  if (config.worker.cors !== "on") return {};
-  return {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
-  };
-}
-
-function htmlHeaders() {
-  return { "content-type": "text/html;charset=UTF-8", ...corsHeaders() };
-}
-
-function jsonHeaders() {
-  return { "content-type": "application/json;charset=UTF-8", ...corsHeaders() };
-}
-
-// ============================================================================
-// Utilities
-// ============================================================================
-
-function randomString(len = config.worker.min_random_key_length) {
-  const chars = config.worker.random_chars;
-  const bytes = new Uint8Array(len);
-  crypto.getRandomValues(bytes);
-  let result = "";
-  for (let i = 0; i < len; i++) {
-    result += chars.charAt(bytes[i] % chars.length);
-  }
-  return result;
-}
-
-async function sha512(text) {
-  const data = new TextEncoder().encode(text);
-  const digest = await crypto.subtle.digest("SHA-512", data);
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function isValidUrl(url) {
-  return typeof url === "string" && url.startsWith("h") && URL_PATTERN.test(url);
-}
-
-function isValidCustomSlug(slug) {
-  return (
-    SLUG_PATTERN.test(slug) &&
-    slug.length >= 1 &&
-    slug.length <= config.worker.max_custom_slug_length &&
-    !config.worker.reserved_slugs.includes(slug.toLowerCase())
-  );
-}
-
-function wantsJson(request) {
-  const accept = request.headers.get("accept") || "";
-  const contentType = request.headers.get("content-type") || "";
-  return accept.includes("application/json") || contentType.includes("application/json");
-}
-
-// ============================================================================
-// KV access
-// ============================================================================
-
-/**
- * Store a URL under a random or custom key.
- * @returns {Promise<[errorCode: string|undefined, key: string|null]>}
- */
-async function saveUrl(url, customSlug = null) {
-  try {
-    const key = customSlug || randomString();
-    const existing = await LINKS.get(key);
-
-    if (existing === null) {
-      await LINKS.put(key, url);
-      return [undefined, key];
-    }
-    if (customSlug) {
-      return ["CUSTOM_SLUG_EXISTS", null];
-    }
-    return saveUrl(url);
-  } catch (error) {
-    console.error("saveUrl failed:", error);
-    return ["KV_ERROR", null];
-  }
-}
-
-async function findUrlKeyByHash(urlHash) {
-  return (await LINKS.get(urlHash)) || null;
-}
-
-// ============================================================================
-// External page / safety helpers
-// ============================================================================
-
-async function fetchHostedPage(url, status = 200) {
-  const upstream = await fetch(url, { redirect: "follow" });
-  return new Response(await upstream.text(), {
-    status,
-    headers: { "content-type": "text/html;charset=UTF-8" },
-  });
-}
-
-async function fetchInterstitial(url, destination) {
-  const upstream = await fetch(url);
-  const html = (await upstream.text()).replace(/{Replace}/gm, destination);
-  return new Response(html, { headers: { "content-type": "text/html;charset=UTF-8" } });
-}
-
-function notFound() {
-  return fetchHostedPage(getEndpoints().notFoundPage, 404);
-}
-
-async function isUrlSafe(url) {
-  const endpoints = getEndpoints();
-  const body = JSON.stringify({
-    client: { clientId: "Url-Shorten-Worker", clientVersion: "1.0.7" },
-    threatInfo: {
-      threatTypes: [
-        "MALWARE",
-        "SOCIAL_ENGINEERING",
-        "POTENTIALLY_HARMFUL_APPLICATION",
-        "UNWANTED_SOFTWARE",
-      ],
-      platformTypes: ["ANY_PLATFORM"],
-      threatEntryTypes: ["URL"],
-      threatEntries: [{ url }],
-    },
+export default withFetchObservability(async (request, env) => {
+  const shortener = createShortener({
+    worker: config.worker,
+    endpoints: getEndpoints(),
+    kv: env.LINKS,
   });
 
-  const response = await fetch(
-    `${endpoints.safeBrowsing}?key=${config.worker.safe_browsing_api_key}`,
-    { method: "POST", body, redirect: "follow" }
-  );
-  const result = await response.json();
-  return Object.keys(result).length === 0;
-}
-
-// ============================================================================
-// Error responses
-// ============================================================================
-
-function jsonResponse(payload, status) {
-  return new Response(JSON.stringify(payload), { status, headers: jsonHeaders() });
-}
-
-async function errorResponse(message, code, request) {
-  if (wantsJson(request)) {
-    return jsonResponse({ status: code, message }, code);
-  }
-  const endpoints = getEndpoints();
-  const url = `${endpoints.errorPage}?message=${encodeURIComponent(message)}&code=${encodeURIComponent(code)}`;
-  return fetchHostedPage(url, code);
-}
-
-// ============================================================================
-// Access control (Cloudflare Zero Trust / WARP)
-// ============================================================================
-
-function hasPassedAccess(request) {
-  const jwt = request.headers.get("Cf-Access-Jwt-Assertion");
-  const email = request.headers.get("Cf-Access-Authenticated-User-Email");
-  // To restrict to specific accounts, gate on `email` here.
-  return Boolean(jwt && email);
-}
-
-// ============================================================================
-// Route handlers
-// ============================================================================
-
-async function resolveShortKey(longUrl, customSlug) {
-  if (config.worker.unique_link && !customSlug) {
-    const urlHash = await sha512(longUrl);
-    const existingKey = await findUrlKeyByHash(urlHash);
-    if (existingKey) {
-      return [undefined, existingKey];
-    }
-    const [errorCode, key] = await saveUrl(longUrl);
-    if (errorCode === undefined) await LINKS.put(urlHash, key);
-    return [errorCode, key];
-  }
-  return saveUrl(longUrl, customSlug);
-}
-
-function respondToSaveError(errorCode, request) {
-  if (errorCode === "CUSTOM_SLUG_EXISTS") {
-    return errorResponse("Custom slug already exists", 400, request);
-  }
-  if (errorCode === "KV_ERROR") {
-    return errorResponse("Database error occurred", 500, request);
-  }
-  return errorResponse("Error: Reach the KV write limitation", 500, request);
-}
-
-async function validateShortenPayload(body, request) {
-  const longUrl = body.url;
-  if (!longUrl) return { error: await errorResponse("URL is required", 400, request) };
-  if (!isValidUrl(longUrl)) {
-    return { error: await errorResponse("Invalid URL format", 400, request) };
-  }
-
-  const customSlug = body.custom_slug || null;
-  if (!customSlug) return { longUrl, customSlug: null };
-
-  if (!config.worker.custom_link) {
-    return { error: await errorResponse("Custom URLs are disabled", 400, request) };
-  }
-  if (!isValidCustomSlug(customSlug)) {
-    return { error: await errorResponse("Invalid custom slug format", 400, request) };
-  }
-  return { longUrl, customSlug };
-}
-
-async function handleShorten(request, requestURL, pathname) {
-  // Only allow shortening via the root endpoint.
-  if (pathname !== "/") {
-    return jsonResponse({ status: 404, message: "Invalid API path" }, 404);
-  }
-
-  if (!hasPassedAccess(request)) {
-    return errorResponse("You must use WARP to shorten the URL", 403, request);
-  }
-
-  let body;
-  try {
-    body = await request.json();
-  } catch (error) {
-    console.error("Invalid JSON body:", error);
-    return errorResponse("Invalid JSON format", 400, request);
-  }
-
-  const validated = await validateShortenPayload(body, request);
-  if (validated.error) return validated.error;
-
-  const [errorCode, key] = await resolveShortKey(validated.longUrl, validated.customSlug);
-  if (errorCode === undefined) {
-    return jsonResponse({ short_url: `${requestURL.origin}/${key}` }, 201);
-  }
-  return respondToSaveError(errorCode, request);
-}
-
-async function handleShortUrlRedirect(path, params) {
-  if (!path) return notFound();
-
-  const value = await LINKS.get(path);
-  if (!value) return notFound();
-
-  const destination = params ? value + params : value;
-  const endpoints = getEndpoints();
-
-  if (config.worker.safe_browsing_api_key && !(await isUrlSafe(destination))) {
-    return fetchInterstitial(endpoints.safeBrowsingWarning, destination);
-  }
-  if (config.worker.no_ref === "on") {
-    return fetchInterstitial(endpoints.noRefPage, destination);
-  }
-  return Response.redirect(destination, 302);
-}
-
-async function handleGet(path, params) {
-  const endpoints = getEndpoints();
-
-  if (path === "") return fetchHostedPage(endpoints.shortenPage);
-  return handleShortUrlRedirect(path, params);
-}
-
-// ============================================================================
-// Router
-// ============================================================================
-
-async function handleRequest(request) {
   const requestURL = new URL(request.url);
   const [, path] = requestURL.pathname.split("/");
   const params = requestURL.search;
 
   if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: htmlHeaders() });
+    return new Response(null, { status: 204, headers: shortener.htmlHeaders() });
   }
   if (request.method === "POST") {
-    return handleShorten(request, requestURL, requestURL.pathname);
+    return shortener.handleShorten(request, requestURL, {
+      apiPath: requestURL.pathname,
+      allowedApiPaths: ["/"],
+    });
   }
-  return handleGet(path, params);
-}
-
-addEventListener("fetch", (event) => {
-  event.respondWith(handleRequest(event.request));
+  if (!path) return shortener.fetchHostedPage(getEndpoints().shortenPage);
+  return shortener.handleShortUrlRedirect(path, params);
 });

--- a/tests/mocks/cloudflare-workers.js
+++ b/tests/mocks/cloudflare-workers.js
@@ -1,0 +1,5 @@
+export const tracing = {
+  enterSpan(_name, callback) {
+    return callback({ isTraced: false, setAttribute() {} });
+  },
+};

--- a/tests/observability.test.js
+++ b/tests/observability.test.js
@@ -2,27 +2,31 @@ import { describe, it, expect, vi } from "vitest";
 import { requestFields } from "../src/lib/observability.js";
 
 describe("requestFields", () => {
-  it("extracts method and path from a request", () => {
-    const request = new Request("https://example.com/shorten?x=1", { method: "POST" });
-
-    expect(requestFields(request)).toEqual({
-      http: { method: "POST", path: "/shorten", query: "?x=1" },
-    });
+  it.each([
+    {
+      name: "method and path",
+      request: new Request("https://example.com/shorten?x=1", { method: "POST" }),
+      expected: { http: { method: "POST", path: "/shorten", query: "?x=1" } },
+    },
+    {
+      name: "empty query",
+      request: new Request("https://example.com/", { method: "GET" }),
+      expected: { http: { method: "GET", path: "/" } },
+    },
+  ])("$name", ({ request, expected }) => {
+    expect(requestFields(request)).toEqual(expected);
   });
 
   it("includes cf metadata when present", () => {
     expect(
-      requestFields({ url: "https://example.com/", method: "GET", cf: { colo: "SIN", country: "SG" } })
+      requestFields({
+        url: "https://example.com/",
+        method: "GET",
+        cf: { colo: "SIN", country: "SG" },
+      })
     ).toEqual({
       http: { method: "GET", path: "/" },
       client: { colo: "SIN", country: "SG" },
-    });
-  });
-
-  it("omits optional fields when absent", () => {
-    const request = new Request("https://example.com/", { method: "GET" });
-    expect(requestFields(request)).toEqual({
-      http: { method: "GET", path: "/" },
     });
   });
 });

--- a/tests/observability.test.js
+++ b/tests/observability.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { requestFields } from "../src/lib/observability.js";
+
+describe("requestFields", () => {
+  it("extracts method and path from a request", () => {
+    const request = new Request("https://example.com/shorten?x=1", { method: "POST" });
+
+    expect(requestFields(request)).toEqual({
+      http: { method: "POST", path: "/shorten", query: "?x=1" },
+    });
+  });
+
+  it("includes cf metadata when present", () => {
+    expect(
+      requestFields({ url: "https://example.com/", method: "GET", cf: { colo: "SIN", country: "SG" } })
+    ).toEqual({
+      http: { method: "GET", path: "/" },
+      client: { colo: "SIN", country: "SG" },
+    });
+  });
+
+  it("omits optional fields when absent", () => {
+    const request = new Request("https://example.com/", { method: "GET" });
+    expect(requestFields(request)).toEqual({
+      http: { method: "GET", path: "/" },
+    });
+  });
+});
+
+describe("log", () => {
+  it("writes structured JSON to console", async () => {
+    const { log } = await import("../src/lib/observability.js");
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    log("info", "test.event", { key: "abc" });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "info",
+        event: "test.event",
+        key: "abc",
+        ts: expect.any(String),
+      })
+    );
+
+    spy.mockRestore();
+  });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
+import { URL_PATTERN, SLUG_PATTERN } from "../src/lib/constants.js";
+import { randomString } from "../src/lib/crypto.js";
+import { isValidUrl, isValidCustomSlug } from "../src/lib/validate.js";
 
-// Test utility functions
+const workerConfig = {
+  min_random_key_length: 6,
+  max_custom_slug_length: 50,
+  random_chars: "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678",
+  reserved_slugs: ["api", "admin", "www", "mail", "ftp", "localhost", "password"],
+};
+
 describe("URL Validation", () => {
   it("should validate correct URLs", () => {
     const validUrls = [
@@ -10,97 +19,56 @@ describe("URL Validation", () => {
       "https://example.com/path?query=value",
     ];
 
-    const urlRegex = /http(s)?:\/\/([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?/;
-
     validUrls.forEach((url) => {
-      expect(urlRegex.test(url)).toBe(true);
-      expect(url[0]).toBe("h");
+      expect(isValidUrl(url)).toBe(true);
+      expect(URL_PATTERN.test(url)).toBe(true);
     });
   });
 
   it("should reject invalid URLs", () => {
     const invalidUrls = ["not-a-url", "ftp://example.com", "example.com", ""];
 
-    const urlRegex = /http(s)?:\/\/([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?/;
-
     invalidUrls.forEach((url) => {
-      const isValid = urlRegex.test(url) && url[0] === "h";
-      expect(isValid).toBe(false);
+      expect(isValidUrl(url)).toBe(false);
     });
   });
 });
 
 describe("Custom Slug Validation", () => {
   it("should validate correct slug formats", () => {
-    const validSlugs = [
-      "my-link",
-      "my_link",
-      "myLink123",
-      "a",
-      "a".repeat(50), // max length
-    ];
-
-    const slugRegex = /^[a-zA-Z0-9\-_]+$/;
-    const maxLength = 50;
-    const reservedSlugs = ["api", "admin", "www", "mail", "ftp", "localhost", "password"];
+    const validSlugs = ["my-link", "my_link", "myLink123", "a", "a".repeat(50)];
 
     validSlugs.forEach((slug) => {
-      expect(slugRegex.test(slug)).toBe(true);
-      expect(slug.length >= 1 && slug.length <= maxLength).toBe(true);
-      expect(reservedSlugs.includes(slug.toLowerCase())).toBe(false);
+      expect(isValidCustomSlug(slug, workerConfig)).toBe(true);
+      expect(SLUG_PATTERN.test(slug)).toBe(true);
     });
   });
 
   it("should reject invalid slug formats", () => {
-    const invalidSlugs = [
-      "my link", // contains space
-      "my@link", // contains special char
-      "my.link", // contains dot
-      "", // empty
-      "a".repeat(51), // too long
-      "api", // reserved
-      "ADMIN", // reserved (case insensitive)
-    ];
-
-    const slugRegex = /^[a-zA-Z0-9\-_]+$/;
-    const maxLength = 50;
-    const reservedSlugs = ["api", "admin", "www", "mail", "ftp", "localhost", "password"];
+    const invalidSlugs = ["my link", "my@link", "my.link", "", "a".repeat(51), "api", "ADMIN"];
 
     invalidSlugs.forEach((slug) => {
-      const isValid =
-        slugRegex.test(slug) &&
-        slug.length >= 1 &&
-        slug.length <= maxLength &&
-        !reservedSlugs.includes(slug.toLowerCase());
-      expect(isValid).toBe(false);
+      expect(isValidCustomSlug(slug, workerConfig)).toBe(false);
     });
   });
 });
 
 describe("Random String Generation", () => {
   it("should generate strings of correct length", () => {
-    const chars = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
-    const minLength = 6;
-    const testLengths = [minLength, 8, 10, 20];
+    const testLengths = [6, 8, 10, 20];
 
     testLengths.forEach((len) => {
-      // Simulate random string generation
-      let result = "";
-      for (let i = 0; i < len; i++) {
-        result += chars.charAt(Math.floor(Math.random() * chars.length));
-      }
+      const result = randomString(workerConfig, len);
       expect(result).toHaveLength(len);
-      // All characters should be from the allowed set
-      expect([...result].every((char) => chars.includes(char))).toBe(true);
+      expect([...result].every((char) => workerConfig.random_chars.includes(char))).toBe(true);
     });
   });
 
   it("should not contain confusing characters", () => {
-    const chars = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
     const confusingChars = ["o", "O", "L", "l", "0", "1", "9", "g", "q", "V", "v", "U", "u", "I"];
 
     confusingChars.forEach((char) => {
-      expect(chars.includes(char)).toBe(false);
+      expect(workerConfig.random_chars.includes(char)).toBe(false);
     });
   });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -10,65 +10,55 @@ const workerConfig = {
   reserved_slugs: ["api", "admin", "www", "mail", "ftp", "localhost", "password"],
 };
 
+const allowedChars = new Set(workerConfig.random_chars);
+
 describe("URL Validation", () => {
-  it("should validate correct URLs", () => {
-    const validUrls = [
-      "https://example.com",
-      "http://example.com",
-      "https://www.example.com/path",
-      "https://example.com/path?query=value",
-    ];
-
-    validUrls.forEach((url) => {
-      expect(isValidUrl(url)).toBe(true);
-      expect(URL_PATTERN.test(url)).toBe(true);
-    });
+  it.each([
+    "https://example.com",
+    "http://example.com",
+    "https://www.example.com/path",
+    "https://example.com/path?query=value",
+  ])("accepts valid URL %s", (url) => {
+    expect(isValidUrl(url)).toBe(true);
+    expect(URL_PATTERN.test(url)).toBe(true);
   });
 
-  it("should reject invalid URLs", () => {
-    const invalidUrls = ["not-a-url", "ftp://example.com", "example.com", ""];
-
-    invalidUrls.forEach((url) => {
+  it.each(["not-a-url", "ftp://example.com", "example.com", ""])(
+    "rejects invalid URL %s",
+    (url) => {
       expect(isValidUrl(url)).toBe(false);
-    });
-  });
+    }
+  );
 });
 
 describe("Custom Slug Validation", () => {
-  it("should validate correct slug formats", () => {
-    const validSlugs = ["my-link", "my_link", "myLink123", "a", "a".repeat(50)];
-
-    validSlugs.forEach((slug) => {
+  it.each(["my-link", "my_link", "myLink123", "a", "a".repeat(50)])(
+    "accepts valid slug %s",
+    (slug) => {
       expect(isValidCustomSlug(slug, workerConfig)).toBe(true);
       expect(SLUG_PATTERN.test(slug)).toBe(true);
-    });
-  });
+    }
+  );
 
-  it("should reject invalid slug formats", () => {
-    const invalidSlugs = ["my link", "my@link", "my.link", "", "a".repeat(51), "api", "ADMIN"];
-
-    invalidSlugs.forEach((slug) => {
+  it.each(["my link", "my@link", "my.link", "", "a".repeat(51), "api", "ADMIN"])(
+    "rejects invalid slug %s",
+    (slug) => {
       expect(isValidCustomSlug(slug, workerConfig)).toBe(false);
-    });
-  });
+    }
+  );
 });
 
 describe("Random String Generation", () => {
-  it("should generate strings of correct length", () => {
-    const testLengths = [6, 8, 10, 20];
-
-    testLengths.forEach((len) => {
-      const result = randomString(workerConfig, len);
-      expect(result).toHaveLength(len);
-      expect([...result].every((char) => workerConfig.random_chars.includes(char))).toBe(true);
-    });
+  it.each([6, 8, 10, 20])("generates strings of length %i", (len) => {
+    const result = randomString(workerConfig, len);
+    expect(result).toHaveLength(len);
+    expect([...result].every((char) => allowedChars.has(char))).toBe(true);
   });
 
-  it("should not contain confusing characters", () => {
-    const confusingChars = ["o", "O", "L", "l", "0", "1", "9", "g", "q", "V", "v", "U", "u", "I"];
-
-    confusingChars.forEach((char) => {
-      expect(workerConfig.random_chars.includes(char)).toBe(false);
-    });
-  });
+  it.each(["o", "O", "L", "l", "0", "1", "9", "g", "q", "V", "v", "U", "u", "I"])(
+    "excludes confusing character %s",
+    (char) => {
+      expect(allowedChars.has(char)).toBe(false);
+    }
+  );
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "cloudflare:workers": path.resolve("./tests/mocks/cloudflare-workers.js"),
+    },
+  },
   test: {
     globals: true,
     environment: "node",

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,0 +1,21 @@
+name = "shorten-url"
+main = "src/worker.js"
+compatibility_date = "2026-01-01"
+
+[[kv_namespaces]]
+binding = "LINKS"
+id = "your-kv-namespace-id"
+
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
+invocation_logs = true
+persist = true
+head_sampling_rate = 1
+
+[observability.traces]
+enabled = true
+persist = true
+head_sampling_rate = 1


### PR DESCRIPTION
## Type of changes

- Refactor

## Purpose

- Extract duplicated Worker logic into reusable `src/lib/` modules so production, dev, and template workers share one implementation.
- Switch the template worker to ES modules and `env.LINKS` bindings for modern Wrangler compatibility.
- Add structured JSON logging and custom trace spans so requests, KV operations, redirects, and Safe Browsing checks are visible in Cloudflare Workers Logs and Traces.

## Additional Information

- New modules: `shortener`, `kv`, `responses`, `validate`, `crypto`, `observability`, and related helpers under `src/lib/`.
- `worker.example.js` is now a thin router that imports from `src/lib/` and wraps the handler with `withFetchObservability()`.
- Added `wrangler.toml.example` with `[observability.logs]` and `[observability.traces]` enabled; local production `wrangler.toml` remains gitignored.
- Tests import shared lib code directly; Vitest mocks `cloudflare:workers` for tracing in Node.
- New `pnpm run logs` script runs `wrangler tail` for live log streaming.